### PR TITLE
added in large breakpoint

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,9 +14,11 @@
   <header class="text-white">
     <!-- nav bar -->
     <nav class="bg-custom-darkest font-accent py-4">
-      <div class="max-container">
-        <img src="./img/logo.svg" alt="CRL logo">
-        <ul class="text-lg py-4 flex flex-col gap-2 items-center">
+      <div class="max-container flex flex-col md:flex-row md:justify-between">
+        <div>
+          <img src="./img/logo.svg" alt="CRL logo">
+        </div>
+        <ul class="text-lg flex flex-col items-center gap-4 md:flex-row">
           <li class="uppercase">Home</li>
           <li class="uppercase">About</li>
           <li class="uppercase">Contact</li>
@@ -66,14 +68,16 @@
       because we don't have a background color on this section, we can put the
       the .max-container on the section itself
     -->
-    <section class="max-container py-20">
-      <!-- It doesn’t have to be so hard -->
-      <h2 class="text-custom-accent font-accent text-4xl pb-6">It doesn’t have to be so hard</h2>
-      <p class="text-xl pb-12">Lorem ipsum dolor sit amet consectetur adipisicing elit. Suscipit in, nemo libero vitae amet eveniet doloremque, repellendus aspernatur neque quos alias perferendis expedita quam ducimus ut quasi earum voluptates tenetur necessitatibus aliquam et nobis! Dolor laborum amet magni fugiat libero?</p>
-      <img class="pb-6" src="./img/hero-img.jpg" alt="blue purple and green watercolor designs">
-      <p class="text-xl pb-6">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Tempora officiis, aliquam itaque repudiandae dicta exercitationem! Iusto voluptatibus consequatur tempora et deleniti asperiores? Aliquam, facilis asperiores.</p>
+    <section class="max-container py-20 flex flex-col lg:flex-row lg:gap-20">
+      <div>
+        <!-- It doesn’t have to be so hard -->
+        <h2 class="text-custom-accent font-accent text-4xl pb-6">It doesn’t have to be so hard</h2>
+        <p class="text-xl pb-12">Lorem ipsum dolor sit amet consectetur adipisicing elit. Suscipit in, nemo libero vitae amet eveniet doloremque, repellendus aspernatur neque quos alias perferendis expedita quam ducimus ut quasi earum voluptates tenetur necessitatibus aliquam et nobis! Dolor laborum amet magni fugiat libero?</p>
+        <img class="pb-6" src="./img/hero-img.jpg" alt="blue purple and green watercolor designs">
+        <p class="text-xl pb-6">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Tempora officiis, aliquam itaque repudiandae dicta exercitationem! Iusto voluptatibus consequatur tempora et deleniti asperiores? Aliquam, facilis asperiores.</p>
+      </div>
       
-      <div class="flex flex-col gap-8 md:flex-row">
+      <div class="flex flex-col gap-8 md:flex-row lg:flex-col">
         <!-- Break It Down -->
         <div class="bg-custom-darker text-white text-center px-8 py-6">
           <h3 class="font-accent text-3xl pb-6">Break It Down</h3>
@@ -96,16 +100,16 @@
   
   <!-- footer section -->
   <footer class="bg-custom-darker text-neutral-300 py-20">
-    <div class="max-container">
-      <h2 class="font-accent text-2xl text-white text-center pb-10">just scratching the surface</h2>
+    <div class="max-container max-w-3xl">
+      <h2 class="font-accent text-3xl text-white text-center pb-10">just scratching the surface</h2>
       
       <!-- About Our Company -->
-      <div class="max-w-3xl md:text-center md:mx-auto">
+      <div class="md:text-center">
         <h4 class="text-custom-accent font-accent text-xl pb-4">About Our Company</h4>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nesciunt distinctio consequuntur quas dolorum, fuga velit accusamus neque ab ipsum ullam temporibus libero impedit, itaque totam.</p>
       </div>
       
-      <div class="pt-10 flex flex-col gap-4 md:flex-row md:justify-around">
+      <div class="pt-10 flex flex-col gap-4 md:flex-row md:justify-between">
         <!-- Getting Around -->
         <div>
           <h4 class="text-custom-accent font-accent text-xl pb-4">Getting Around</h4>

--- a/src/input.css
+++ b/src/input.css
@@ -21,6 +21,6 @@
   */
   .max-container {
     /* @apply max-w-[1200px] mx-auto px-4; */
-    @apply max-w-7xl mx-auto px-4;
+    @apply max-w-7xl mx-auto px-8;
   }
 }


### PR DESCRIPTION
nav menu goes horizontal at medium screens (missed that in the previous commit)
main content goes two columns at large screens
customized the footer a bit because it felt like we had too much white space
bumped up the max-container horizontal padding

I have a few other tweaks I want to play with, but I wanted to get this committed before I break something or go down the rabbit hole on something.

small screens (<768px):

<img width="816" alt="Screen Shot 2022-01-07 at 7 55 20 PM" src="https://user-images.githubusercontent.com/31823413/148624817-45475a22-efbc-465c-a93b-c0d2129ff32b.png">

<img width="837" alt="Screen Shot 2022-01-07 at 7 55 48 PM" src="https://user-images.githubusercontent.com/31823413/148624821-08f591ad-9abf-4890-8081-206795d93f31.png">

<img width="847" alt="Screen Shot 2022-01-07 at 7 55 58 PM" src="https://user-images.githubusercontent.com/31823413/148624825-3ff019ff-36d2-4664-ae2f-0fa8d9411100.png">

medium screen (>768):

<img width="860" alt="Screen Shot 2022-01-07 at 7 57 01 PM" src="https://user-images.githubusercontent.com/31823413/148624868-f260d86f-34f4-4de4-8018-72f50b9fe1bd.png">

<img width="864" alt="Screen Shot 2022-01-07 at 7 57 40 PM" src="https://user-images.githubusercontent.com/31823413/148624895-c4f638d7-d15c-4b3e-8765-45298c06f1a0.png">

<img width="853" alt="Screen Shot 2022-01-07 at 7 58 14 PM" src="https://user-images.githubusercontent.com/31823413/148624924-2a0cfe76-6dcd-432c-b339-4acf5659a933.png">

large screen (>=1024)

<img width="1071" alt="Screen Shot 2022-01-07 at 8 01 36 PM" src="https://user-images.githubusercontent.com/31823413/148625078-77d24d74-1a34-4193-a1ce-980a210da62f.png">





