### PR TITLE
clean up footer

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -100,48 +100,68 @@
   
   <!-- footer section -->
   <footer class="bg-custom-darker text-neutral-300 py-20">
-    <div class="max-container max-w-3xl">
-      <h2 class="font-accent text-3xl text-white text-center pb-10">just scratching the surface</h2>
+    <div class="max-container">
       
-      <!-- About Our Company -->
-      <div class="md:text-center">
-        <h4 class="text-custom-accent font-accent text-xl pb-4">About Our Company</h4>
-        <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nesciunt distinctio consequuntur quas dolorum, fuga velit accusamus neque ab ipsum ullam temporibus libero impedit, itaque totam.</p>
-      </div>
-      
-      <div class="pt-10 flex flex-col gap-4 md:flex-row md:justify-between">
-        <!-- Getting Around -->
-        <div>
-          <h4 class="text-custom-accent font-accent text-xl pb-4">Getting Around</h4>
-          <ul>
-            <li>Home</li>
-            <li>About</li>
-            <li>Contact</li>
-          </ul>
+      <!-- I think the font size in the spec is wrong.  24px seems way to small -->
+      <h2 class="font-accent text-5xl text-white text-center pb-12">just scratching the surface</h2>
+  
+      <div class="flex flex-col gap-8 lg:flex-row lg:gap-24">
+        
+        <!-- About Our Company -->
+        <div class="lg:basis-2/5">
+          <h4 class="text-custom-accent font-accent text-xl pb-4">About Our Company</h4>
+          <p class="max-w-xl">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nesciunt distinctio consequuntur quas dolorum, fuga velit accusamus neque ab ipsum ullam temporibus libero impedit, itaque totam.</p>
         </div>
-      
-        <!-- Other Things -->
-        <div>
-          <h4 class="text-custom-accent font-accent text-xl pb-4">Other Things</h4>
-          <ul>
-            <li>Lorem ipsum</li>
-            <li>dolor</li>
-            <li>sit amet</li>
-            <li>consectetur</li>
-          </ul>
-        </div>
-        <!-- And More -->
-        <div>
-          <h4 class="text-custom-accent font-accent text-xl pb-4">And More</h4>
-          <ul>
-            <li>Lorem ipsum</li>
-            <li>dolor</li>
-            <li>sit amet</li>
-            <li>consectetur</li>
-          </ul>
-        </div>
-      </div>
-    </div>
+        
+        <div class="flex flex-col gap-4 md:flex-row md:justify-between lg:basis-3/5">
+          <!-- Getting Around -->
+          <div class="">
+            <h4 class="text-custom-accent font-accent text-xl pb-4">Getting Around</h4>
+            <ul class="leading-7">
+              <li>Home</li>
+              <li>About</li>
+              <li>Contact</li>
+            </ul>
+          </div>
+        
+          <!-- Other Things -->
+          <div class="">
+            <h4 class="text-custom-accent font-accent text-xl pb-4">Other Things</h4>
+            <ul class="leading-7">
+              <li>Lorem ipsum</li>
+              <li>dolor</li>
+              <li>sit amet</li>
+              <li>consectetur</li>
+            </ul>
+          </div>
+
+          <!-- And More -->
+          <div class="">
+            <h4 class="text-custom-accent font-accent text-xl pb-4">And More</h4>
+            <ul class="leading-7">
+              <li>Lorem ipsum</li>
+              <li>dolor</li>
+              <li>sit amet</li>
+              <li>consectetur</li>
+            </ul>
+          </div>
+        </div> <!-- end inner flex -->
+
+      </div> <!-- end outer flex -->
+
+    </div> <!-- end max-container -->
   </footer>
 </body>
+
+  <script>
+        document.addEventListener("DOMContentLoaded", function(event) { 
+            var scrollpos = localStorage.getItem('scrollpos');
+            if (scrollpos) window.scrollTo(0, scrollpos);
+        });
+
+        window.onbeforeunload = function(e) {
+            localStorage.setItem('scrollpos', window.scrollY);
+        };
+    </script>
+
 </html>


### PR DESCRIPTION
went back to the spec layout for the most part.  I treated it like the main section with a flexbox inside a flexbox.

I also increased the footer title font as what's in the spec seems way to small based on the visual in the spec

at 1400 px wide:
<img width="1565" alt="Screen Shot 2022-01-14 at 1 28 20 PM" src="https://user-images.githubusercontent.com/31823413/149566630-ff921e9e-12a3-48cf-b17c-504bff1f2278.png">

at the start of the "large" break point:
<img width="1070" alt="Screen Shot 2022-01-14 at 1 28 09 PM" src="https://user-images.githubusercontent.com/31823413/149566633-bf9d698d-a951-460b-a23e-c142b2d903fd.png">

just before the "large" break point:
<img width="1026" alt="Screen Shot 2022-01-14 at 1 27 42 PM" src="https://user-images.githubusercontent.com/31823413/149566634-00466624-e6bb-4d35-935c-91abe1909a6b.png">

at the start of the "medium" breakpoint:
<img width="775" alt="Screen Shot 2022-01-14 at 1 27 17 PM" src="https://user-images.githubusercontent.com/31823413/149566635-30e703da-e3ae-4621-a937-2e9b752287af.png">

just before the "medium" breakpoint:
<img width="774" alt="Screen Shot 2022-01-14 at 1 27 04 PM" src="https://user-images.githubusercontent.com/31823413/149566636-3ca8ee85-8aa6-45de-9f96-b8b209304a38.png">

the mobile view:
<img width="742" alt="Screen Shot 2022-01-14 at 1 26 30 PM" src="https://user-images.githubusercontent.com/31823413/149566638-f4823f3b-28d7-47f5-b54d-cb90a0ecc49c.png">

